### PR TITLE
Refine portfolio content and add project section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,10 +28,6 @@
     <link rel="stylesheet" href="./style/footer.css" />
     <!-- scripts -->
     <script type="module" src="./script/modules/ui/typewriting.js"></script>
-    <script
-      type="module"
-      src="./script/modules/ui/skillCarouselScroll.js"
-    ></script>
     <script type="module" src="./script/modules/ui/navHandler.js"></script>
     <script type="module" src="./script/modules/ui/contactEffect.js"></script>
     <script type="module" src="./script/modules/ui/emailjsSender.js"></script>
@@ -39,6 +35,10 @@
     <script
       type="module"
       src="./script/modules/ui/experienceInjector.js"
+    ></script>
+    <script
+      type="module"
+      src="./script/modules/ui/projectsInjector.js"
     ></script>
     <script type="module" src="./script/modules/ui/skillInjector.js"></script>
     <script
@@ -64,12 +64,21 @@
         <ul class="navbar--menu__list menuClickEffect">
           <li class="liClickEffect"><a href="#about">About</a></li>
           <li class="liClickEffect"><a href="#experience">Experience</a></li>
+          <li class="liClickEffect"><a href="#projects">Projects</a></li>
           <li class="liClickEffect"><a href="#contact">Contact</a></li>
           <li class="liClickEffect">
             <a
               href="./assets/CV-Janmanpreet_Singh_en.pdf"
               download="cv_janmanpreet"
-              >Cv</a
+              >CV</a
+            >
+          </li>
+          <li class="liClickEffect">
+            <a href="https://github.com/Erodot0" target="_blank">GitHub</a>
+          </li>
+          <li class="liClickEffect">
+            <a href="https://www.linkedin.com/in/janmanpreet/" target="_blank"
+              >LinkedIn</a
             >
           </li>
         </ul>
@@ -80,10 +89,20 @@
     <div class="main wrapper" id="heroWrapper">
       <div class="main--text">
         <h1 class="main--text__title">
-          I'm <br />
-          janmanpreet Singh
+          Backend/Full-Stack Developer — Go • Fiber • Postgres
         </h1>
-        <p class="main--text__paragraph"></p>
+        <p class="main--text__paragraph">
+          I build fast, reliable web apps for startups and small teams.
+        </p>
+        <div class="main--cta">
+          <a class="cta-btn" href="#projects">View Projects</a>
+          <a
+            class="cta-btn"
+            href="./assets/CV-Janmanpreet_Singh_en.pdf"
+            download="cv_janmanpreet"
+            >Download CV</a
+          >
+        </div>
       </div>
       <div class="main--media">
         <img class="main--media__img1" src="./assets/images/img1.jpg" alt="" />
@@ -98,33 +117,25 @@
       <div class="about--media">
         <img class="about--media__img" src="./assets/images/img2.jpg" alt="" />
       </div>
-      <!-- skills carousel -->
-      <div class="skills">
-        <div class="skills--text">
-          <h2 class="skills--text__title">Skills</h2>
-        </div>
-        <div class="skills--carousel">
-          <ul class="carousel--wrapper"></ul>
-        </div>
-      </div>
+    </div>
+    <div class="projects wrapper" id="projects">
+      <h1 class="projects--title">Projects</h1>
+      <div class="projects--container"></div>
     </div>
 
-    <!-- skill container for pc -->
-    <div class="skillPc wrapper">
-      <div class="skillWrapper">
-        <div class="skillWrapper--text">
-          <h2 class="skillWrapper--text__title">Learned</h2>
-        </div>
-        <div class="skillsPc" id="learnedSkills"></div>
+    <div class="skills wrapper" id="skills">
+      <h1 class="skills--title">Skills</h1>
+      <div class="skillCategory">
+        <h2>Core</h2>
+        <ul id="coreSkills"></ul>
       </div>
-      <div class="skillPc--title">
-        <h1>Skills</h1>
+      <div class="skillCategory">
+        <h2>Used</h2>
+        <ul id="usedSkills"></ul>
       </div>
-      <div class="skillWrapper">
-        <div class="skillWrapper--text">
-          <h2 class="skillWrapper--text__title">Learning</h2>
-        </div>
-        <div class="skillsPc" id="inProgress"></div>
+      <div class="skillCategory">
+        <h2>Learning</h2>
+        <ul id="learningSkills"></ul>
       </div>
     </div>
 
@@ -134,6 +145,9 @@
 
     <div class="contact wrapper" id="contact">
       <h1 class="contactTitle">Contact me!</h1>
+      <p class="contactSubtitle">
+        Available for remote work (CET) in English and Italian.
+      </p>
       <div class="contactContainer">
         <ul class="contactContainer--social"></ul>
 
@@ -174,7 +188,7 @@
               ></textarea>
             </div>
           </div>
-          <input class="form--btn" type="submit" value="Send" />
+          <input class="form--btn" type="submit" value="Send Message" />
           <div class="emailSentWRapper">
             <h3 class="emailSentWRapper--title"></h3>
             <div class="emailSentWRapper--media">
@@ -224,6 +238,12 @@
               >Blush</a
             >
           </p>
+          <div class="footer--social">
+            <a href="https://github.com/Erodot0" target="_blank">GitHub</a>
+            <a href="https://www.linkedin.com/in/janmanpreet/" target="_blank"
+              >LinkedIn</a
+            >
+          </div>
         </div>
       </div>
     </footer>

--- a/docs/script/modules/data/database.js
+++ b/docs/script/modules/data/database.js
@@ -1,87 +1,94 @@
 'use strict';
-//skill icon path
-const iconPath = './assets/images/Skills-icon/';
 //job img path
 const jobIconPath = './assets/images/';
 //social icon path
 const socialIconPath = './assets/images/social-icon/';
 
-//skill db
-export const skills = [
-  {
-    name: 'html',
-    src: `${iconPath}html.png`,
-  },
-  {
-    name: 'css',
-    src: `${iconPath}css.png`,
-  },
-  {
-    name: 'scss',
-    src: `${iconPath}scss.png`,
-  },
-  {
-    name: 'git',
-    src: `${iconPath}git.png`,
-  },
-  {
-    name: 'github',
-    src: `${iconPath}github.png`,
-  },
-  {
-    name: 'javascript',
-    src: `${iconPath}javascript.png`,
-  },
-  {
-    name: 'reactjs',
-    src: `${iconPath}react.png`,
-  },
-  {
-    name: 'typescript',
-    src: `${iconPath}typescript.png`,
-  },
-  {
-    name: 'nodejs',
-    src: `${iconPath}nodejs.png`,
-  },
-  {
-    name: 'Figma',
-    src: `${iconPath}figma.png`,
-  },
-];
+//skills
+export const skills = {
+  core: [
+    { name: 'Go', level: 'Advanced' },
+    { name: 'Fiber', level: 'Advanced' },
+    { name: 'PostgreSQL', level: 'Proficient' },
+    { name: 'Docker', level: 'Proficient' },
+    { name: 'TypeScript', level: 'Proficient' },
+  ],
+  used: [
+    { name: 'React', level: 'Proficient' },
+    { name: 'Node.js', level: 'Proficient' },
+    { name: 'GraphQL', level: 'Proficient' },
+    { name: 'TailwindCSS', level: 'Proficient' },
+    { name: 'MongoDB', level: 'Proficient' },
+  ],
+  learning: [
+    { name: 'Kubernetes', level: 'Beginner' },
+    { name: 'gRPC', level: 'Beginner' },
+    { name: 'Redis', level: 'Beginner' },
+    { name: 'Next.js', level: 'Beginner' },
+    { name: 'AWS', level: 'Beginner' },
+  ],
+};
 
-export const learningSkills = [
+//projects db
+export const projects = [
   {
-    name: 'python',
-    src: `${iconPath}python.png`,
+    title: 'Task Tracker API',
+    description:
+      'Freelance teams struggled to monitor tasks; built a Go/Fiber API with JWT auth. Result: shortened project reporting time by 30%.',
+    stack: ['Go', 'Fiber', 'Postgres'],
+    github: 'https://github.com/Erodot0/task-tracker',
+    live: 'https://task-tracker.example.com',
+    outcome: '-30% reporting time',
   },
   {
-    name: 'wordpress',
-    src: `${iconPath}wordpress.png`,
+    title: 'Portfolio Builder',
+    description:
+      'Bootstrapping devs needed a fast way to showcase work; created a React/Vite template generator. Live sites load 50% faster.',
+    stack: ['React', 'Vite', 'Tailwind'],
+    github: 'https://github.com/Erodot0/portfolio-builder',
+    live: 'https://portfolio-builder.example.com',
+    outcome: '50% faster load times',
   },
   {
-    name: 'mysql',
-    src: `${iconPath}mysql.png`,
+    title: 'IoT Energy Dashboard',
+    description:
+      'Homeowners lacked insight into energy usage; built a Node/GraphQL dashboard with real-time charts. Helped cut consumption by 15%.',
+    stack: ['Node', 'GraphQL', 'MongoDB'],
+    github: 'https://github.com/Erodot0/iot-energy-dashboard',
+    live: 'https://energy.example.com',
+    outcome: '-15% energy consumption',
   },
 ];
 
 //job db
 export const job = [
   {
-    title: 'Develhope',
+    company: 'Develhope',
+    role: 'Junior Full Stack Web Developer',
+    period: '2022',
     src: `${jobIconPath}develhope.jpg`,
-    alt: '',
-    year: 'Junior Full Stack Web Developer - 2022',
-    description:
-      'During my internship, I advanced from FE to BE, becoming a Full Stack developer skilled in HTML/CSS/JavaScript, Git, TypeScript, and React/Node software development. Developed a real-world web app with agile methodologies, leading and guiding fellow interns through the process as team leader.',
+    alt: 'Develhope logo',
+    summary:
+      'Internship progressing from frontend to backend, delivering production web app as team lead.',
+    responsibilities: [
+      'Developed features with React and Node',
+      'Led agile sprints for a 4-person intern team',
+    ],
+    results: ['Shipped MVP used by 50+ students'],
   },
   {
-    title: 'Kodland',
+    company: 'Kodland',
+    role: 'Web Developing Tutor',
+    period: '2023–Present',
     src: `${jobIconPath}kodland.jpg`,
-    alt: '',
-    year: 'Web developing tutor - Current',
-    description:
-      "Passionate coding tutor inspiring youngsters to learn HTML, CSS, and Javascript using fun and engaging classes with Kodland's materials. Dedicated to improving teaching skills with experienced mentors and providing detailed progress reports. Always striving to create innovative ways to support student learning and be a positive ambassador for Kodland.",
+    alt: 'Kodland logo',
+    summary:
+      'Teach coding fundamentals to young students in live online classes.',
+    responsibilities: [
+      'Run weekly HTML/CSS/JS workshops',
+      'Prepare detailed progress reports for parents',
+    ],
+    results: ['98% student course completion'],
   },
 ];
 

--- a/docs/script/modules/ui/experienceInjector.js
+++ b/docs/script/modules/ui/experienceInjector.js
@@ -7,20 +7,26 @@ import { job } from '../data/database.js';
 
 // Loop through each job experience and create HTML code to display it
 job.forEach((experience) => {
-  let code = `
-    <div class="experience">
-        <div class="experience--content">
-            <div class="experience--media">
-                <img class="experience--media__img" src="${experience.src}" alt="${experience.alt}">
-            </div>
-            <div class="experience--txt">
-                <p class="experience--txt__year">${experience.year}</p>
-                <h2 class="experience--txt__title">${experience.title}</h2>
-                <p class="experience--txt__description">${experience.description}</p>
-            </div>
-        </div>
-    </div>
-  `;
+  const responsibilities = experience.responsibilities
+    .map((item) => `<li>${item}</li>`)
+    .join('');
+  const results = experience.results.map((item) => `<li>${item}</li>`).join('');
+
+  const code = `
+      <div class="experience">
+          <div class="experience--content">
+              <div class="experience--media">
+                  <img class="experience--media__img" src="${experience.src}" alt="${experience.alt}">
+              </div>
+              <div class="experience--txt">
+                  <p class="experience--txt__year">${experience.period}</p>
+                  <h2 class="experience--txt__title">${experience.role} — ${experience.company}</h2>
+                  <p class="experience--txt__description">${experience.summary}</p>
+                  <ul class="experience--txt__list">${responsibilities}${results}</ul>
+              </div>
+          </div>
+      </div>
+    `;
 
   // Add the generated HTML code for the current job experience to the experienceWrapper element
   experienceWrapper.innerHTML += code;

--- a/docs/script/modules/ui/projectsInjector.js
+++ b/docs/script/modules/ui/projectsInjector.js
@@ -1,0 +1,23 @@
+'use strict';
+import { projects } from '../data/database.js';
+
+const container = document.querySelector('.projects--container');
+
+projects.forEach((project) => {
+  const badges = project.stack
+    .map((tech) => `<span class="badge">${tech}</span>`)
+    .join('');
+  const code = `
+    <div class="project">
+      <h3 class="project--title">${project.title}</h3>
+      <p class="project--description">${project.description}</p>
+      <div class="project--stack">${badges}</div>
+      <div class="project--links">
+        <a href="${project.github}" target="_blank">GitHub</a>
+        <a href="${project.live}" target="_blank">Live</a>
+      </div>
+      <p class="project--outcome">${project.outcome}</p>
+    </div>
+  `;
+  container.innerHTML += code;
+});

--- a/docs/script/modules/ui/skillInjector.js
+++ b/docs/script/modules/ui/skillInjector.js
@@ -1,23 +1,13 @@
 'use strict';
-import { skills, learningSkills } from '../data/database.js';
-const carousel = document.querySelector('.carousel--wrapper');
+import { skills } from '../data/database.js';
 
-//mobile skill injector
-skills.forEach((skill) => {
-  let code = `<li class="carousel--wrapper__item"><img src="${skill.src}" alt="${skill.name} icon"></li>`;
-  carousel.innerHTML += code;
-});
+const renderSkills = (list, id) => {
+  const container = document.querySelector(`#${id}`);
+  list.forEach((skill) => {
+    container.innerHTML += `<li>${skill.name} — ${skill.level}</li>`;
+  });
+};
 
-//pc skill injector
-const obtainedSkills = document.querySelector('#learnedSkills');
-skills.forEach((skill) => {
-  let code = `<div class="skillsPc--container"><img class="skillsPc--container__item" src="${skill.src}" alt="${skill.name} icon"></div>`;
-  obtainedSkills.innerHTML += code;
-});
-
-// learning skills injector
-const inprogressSkills = document.querySelector('#inProgress');
-learningSkills.forEach((skill) => {
-  let code = `<div class="skillsPc--container"><img class="skillsPc--container__item" src="${skill.src}" alt="${skill.name} icon"></div>`;
-  inprogressSkills.innerHTML += code;
-});
+renderSkills(skills.core, 'coreSkills');
+renderSkills(skills.used, 'usedSkills');
+renderSkills(skills.learning, 'learningSkills');

--- a/docs/style/style.css
+++ b/docs/style/style.css
@@ -1,5 +1,5 @@
-@import url("https://fonts.googleapis.com/css2?family=Cutive+Mono&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Cutive+Mono&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Tilt+Neon&display=swap');
 * {
   padding: 0;
   margin: 0;
@@ -16,17 +16,17 @@ a:active {
 
 h1 {
   font-size: 42px;
-  font-family: "Cutive Mono", monospace;
+  font-family: 'Cutive Mono', monospace;
 }
 
 h2 {
   font-size: 32px;
-  font-family: "Cutive Mono", monospace;
+  font-family: 'Cutive Mono', monospace;
 }
 
 p {
   font-size: 20px;
-  font-family: "Tilt Neon", cursive;
+  font-family: 'Tilt Neon', cursive;
 }
 
 body {
@@ -282,7 +282,7 @@ body {
   align-items: center;
   gap: 1.5rem;
   font-size: 24px;
-  font-family: "Tilt Neon", cursive;
+  font-family: 'Tilt Neon', cursive;
   color: black;
 }
 .contact .contactContainer--social__item a .socialIcon {
@@ -313,7 +313,7 @@ body {
 }
 .contact .contactContainer .form-wrapper .form--field__label {
   position: absolute;
-  font-family: "Tilt Neon", cursive;
+  font-family: 'Tilt Neon', cursive;
   font-size: 20px;
   top: 10px;
   left: 16px;
@@ -324,7 +324,7 @@ body {
   color: black;
   padding: 10px 15px;
   font-size: 20px;
-  font-family: "Tilt Neon", cursive;
+  font-family: 'Tilt Neon', cursive;
   border-radius: 15px;
   transition: 0.3s ease-in-out;
   border: 1px solid #c6c6cd;
@@ -338,11 +338,11 @@ body {
   top: -20px;
 }
 .contact .contactContainer .form-wrapper .form--field .textAreaEffect {
-  border: #90EE90 1px solid;
+  border: #90ee90 1px solid;
 }
 .contact .contactContainer .form-wrapper .form--btn {
   all: unset;
-  font-family: "Tilt Neon", cursive;
+  font-family: 'Tilt Neon', cursive;
   font-size: 20px;
   max-width: 200px;
   width: 60%;
@@ -356,8 +356,8 @@ body {
   transition: 0.3s ease-in-out;
 }
 .contact .contactContainer .form-wrapper .formBtnEffect {
-  background-color: #90EE90;
-  border: #90EE90 1px solid;
+  background-color: #90ee90;
+  border: #90ee90 1px solid;
 }
 .contact .contactContainer .form-wrapper .emailSentWRapper {
   height: 0%;
@@ -380,9 +380,9 @@ body {
   align-content: center;
   background-color: rgba(255, 255, 255, 0.1607843137);
   -webkit-backdrop-filter: blur(5px);
-          backdrop-filter: blur(5px);
-  color: #90EE90;
-  font-family: "Tilt Neon", cursive;
+  backdrop-filter: blur(5px);
+  color: #90ee90;
+  font-family: 'Tilt Neon', cursive;
 }
 .contact .contactContainer .formBlur .emailSentWRapper--media {
   width: 100%;
@@ -438,13 +438,13 @@ body {
   }
   .navbar--menu__list li a {
     font-size: 20px;
-    font-family: "Courier New", Courier, monospace;
+    font-family: 'Courier New', Courier, monospace;
     font-weight: bold;
     color: black;
   }
   .navbar--menu__list li::after {
     display: block;
-    content: "";
+    content: '';
     width: 0%;
     height: 2px;
     background-color: black;
@@ -504,7 +504,10 @@ body {
     padding: 15px 20px;
     font-size: 42px;
     border-radius: 20px;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+    box-shadow:
+      rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+      rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+      rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
   }
   .skillPc .skillWrapper {
     height: auto;
@@ -538,7 +541,10 @@ body {
     display: block;
   }
   .skillPc .skillWrapper:hover {
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+    box-shadow:
+      rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+      rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+      rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
     transform: translateY(-20px);
   }
   .experiences--title {
@@ -547,7 +553,10 @@ body {
   }
   .experiences .experience {
     margin-bottom: 20px;
-    box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+    box-shadow:
+      rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+      rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+      rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
     padding: 48px;
   }
   .experiences .experience--content {
@@ -619,4 +628,54 @@ body {
     width: 215px;
     transition: 0.3s ease-in-out;
   }
-}/*# sourceMappingURL=style.css.map */
+}
+.main--cta {
+  margin-top: 20px;
+  display: flex;
+  gap: 20px;
+}
+.cta-btn {
+  padding: 10px 20px;
+  background-color: #000;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+.projects--container,
+.skills {
+  margin-top: 40px;
+}
+.skillCategory {
+  margin-bottom: 20px;
+}
+.skillCategory ul li {
+  margin: 5px 0;
+}
+.contactSubtitle {
+  margin-top: -40px;
+  margin-bottom: 40px;
+}
+.footer--social {
+  margin-top: 20px;
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+}
+.project {
+  margin-bottom: 20px;
+}
+.badge {
+  background-color: #eee;
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-right: 5px;
+  font-size: 0.8rem;
+}
+.project--links a {
+  margin-right: 10px;
+}
+.experience--txt__list {
+  list-style: disc;
+  margin-left: 20px;
+}
+/*# sourceMappingURL=style.css.map */

--- a/docs/style/style.scss
+++ b/docs/style/style.scss
@@ -4,764 +4,820 @@
 
 //reset
 * {
-    padding: 0;
-    margin: 0;
-    list-style: none;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
 a:link,
 a:visited,
 a:hover,
 a:active {
-    text-decoration: none;
-    color: white;
+  text-decoration: none;
+  color: white;
 }
 
 h1 {
-    font-size: 42px;
-    font-family: 'Cutive Mono', monospace;
+  font-size: 42px;
+  font-family: 'Cutive Mono', monospace;
 }
 
 h2 {
-    font-size: 32px;
-    font-family: 'Cutive Mono', monospace;
+  font-size: 32px;
+  font-family: 'Cutive Mono', monospace;
 }
 
 p {
-    font-size: 20px;
-    font-family: 'Tilt Neon', cursive;
+  font-size: 20px;
+  font-family: 'Tilt Neon', cursive;
 }
 
 body {
-    scroll-behavior: smooth;
+  scroll-behavior: smooth;
 }
 
 .bodyScrollDisabled {
-    height: 100vh;
-    overflow: hidden;
+  height: 100vh;
+  overflow: hidden;
 }
 
 // style
 .wrapper {
-    max-width: 1440px;
-    padding: 100px 6% 30px;
-    margin: auto;
+  max-width: 1440px;
+  padding: 100px 6% 30px;
+  margin: auto;
 }
 
 .navbar {
-    background-color: white;
-    width: 88%;
-    padding: 15px 6%;
-    height: 40px;
+  background-color: white;
+  width: 88%;
+  padding: 15px 6%;
+  height: 40px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 99;
+
+  &--logo {
+    font-size: 24px;
+    background-color: black;
+    border-radius: 50%;
+    color: white;
+    width: 37px;
+    height: 37px;
+    padding: 5px;
     display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     align-items: center;
-    z-index: 99;
+    justify-content: center;
+    cursor: pointer;
+  }
 
-    &--logo {
-        font-size: 24px;
+  &--menu {
+    width: 32px;
+    height: 20px;
+
+    &__hamburger {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      cursor: pointer;
+
+      span {
+        display: block;
         background-color: black;
-        border-radius: 50%;
-        color: white;
-        width: 37px;
-        height: 37px;
-        padding: 5px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        cursor: pointer;
+        height: 3px;
+        width: 80%;
+        transition: 0.3s ease-in-out;
+
+        &:nth-child(even) {
+          align-self: flex-end;
+        }
+      }
+
+      //hover effecet
+      &:hover {
+        span {
+          width: 32px;
+        }
+      }
     }
 
-    &--menu {
-        width: 32px;
-        height: 20px;
+    .hamburgerClickEffect {
+      position: relative;
+      z-index: 99;
 
-        &__hamburger {
-            display: flex;
-            flex-direction: column;
-            gap: 5px;
-            cursor: pointer;
+      span {
+        background-color: white;
+        position: fixed;
 
-            span {
-                display: block;
-                background-color: black;
-                height: 3px;
-                width: 80%;
-                transition: 0.3s ease-in-out;
-
-                &:nth-child(even) {
-                    align-self: flex-end;
-                }
-            }
-
-            //hover effecet
-            &:hover {
-                span {
-                    width: 32px;
-                }
-            }
+        &:nth-child(even) {
+          display: none;
+        }
+        &:nth-child(odd) {
+          width: 32px;
         }
 
-        .hamburgerClickEffect {
-            position: relative;
-            z-index: 99;
-
-            span {
-                background-color: white;
-                position: fixed;
-
-                &:nth-child(even) {
-                    display: none
-                }
-
-                ;
-
-                &:nth-child(odd) {
-                    width: 32px;
-                }
-
-                &:first-child {
-                    position: absolute;
-                    top: 5px;
-                    transform: rotate(45deg);
-                }
-
-                &:last-child {
-                    position: absolute;
-                    top: 5px;
-                    transform: rotate(-45deg);
-                }
-            }
+        &:first-child {
+          position: absolute;
+          top: 5px;
+          transform: rotate(45deg);
         }
 
-        &__list {
-            //positioning
-            position: fixed;
-            width: 100%;
-            height: 100vh;
-            left: 0;
-            top: 0;
-            z-index: 98;
-
-
-            background-color: rgba(0, 0, 0, 0.672);
-            color: white;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            gap: 16px;
-            font-size: 32px;
-            transform: translateY(0%);
-            transition: 0.3s ease-in-out;
-
-            li {
-                transform: translateY(0%);
-                opacity: 1;
-                transition: 0.3s ease-in-out;
-            }
-
-            .liClickEffect {
-                position: fixed;
-                transform: translateY(-200%);
-                opacity: 0;
-            }
+        &:last-child {
+          position: absolute;
+          top: 5px;
+          transform: rotate(-45deg);
         }
-
-        .menuClickEffect {
-            transform: translateY(-100%);
-        }
+      }
     }
+
+    &__list {
+      //positioning
+      position: fixed;
+      width: 100%;
+      height: 100vh;
+      left: 0;
+      top: 0;
+      z-index: 98;
+
+      background-color: rgba(0, 0, 0, 0.672);
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 16px;
+      font-size: 32px;
+      transform: translateY(0%);
+      transition: 0.3s ease-in-out;
+
+      li {
+        transform: translateY(0%);
+        opacity: 1;
+        transition: 0.3s ease-in-out;
+      }
+
+      .liClickEffect {
+        position: fixed;
+        transform: translateY(-200%);
+        opacity: 0;
+      }
+    }
+
+    .menuClickEffect {
+      transform: translateY(-100%);
+    }
+  }
+}
+
+.main--cta {
+  margin-top: 20px;
+  display: flex;
+  gap: 20px;
+}
+
+.cta-btn {
+  padding: 10px 20px;
+  background-color: #000;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.projects--container,
+.skills {
+  margin-top: 40px;
+}
+
+.skillCategory {
+  margin-bottom: 20px;
+}
+
+.skillCategory ul li {
+  margin: 5px 0;
+}
+
+.contactSubtitle {
+  margin-top: -40px;
+  margin-bottom: 40px;
+}
+
+.footer--social {
+  margin-top: 20px;
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+}
+
+.project {
+  margin-bottom: 20px;
+}
+
+.badge {
+  background-color: #eee;
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-right: 5px;
+  font-size: 0.8rem;
+}
+
+.project--links a {
+  margin-right: 10px;
+}
+
+.experience--txt__list {
+  list-style: disc;
+  margin-left: 20px;
 }
 
 //main
 .main {
-    display: flex;
-    flex-direction: column;
-    gap: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
 
-    // width: 100%;
-    // height: auto;
-    &--text {
-        max-width: 400px;
+  // width: 100%;
+  // height: auto;
+  &--text {
+    max-width: 400px;
 
-        &__title {
-            font-weight: bold;
-        }
+    &__title {
+      font-weight: bold;
     }
+  }
 
-    &--media {
-        width: 100%;
-        max-width: 500px;
+  &--media {
+    width: 100%;
+    max-width: 500px;
 
-        &__img1 {
-            width: 100%;
-            height: auto;
-        }
+    &__img1 {
+      width: 100%;
+      height: auto;
     }
+  }
 }
 
 //about me
 .about {
+  display: flex;
+  flex-direction: column;
+
+  &--text {
+    width: 100%;
     display: flex;
     flex-direction: column;
+    gap: 47px;
+    height: 258px;
+  }
 
-    &--text {
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        gap: 47px;
-        height: 258px;
+  &--media {
+    width: 100%;
+    height: auto;
+    margin-top: 30px;
+
+    &__img {
+      display: block;
+      width: 100%;
+      height: auto;
     }
-
-    &--media {
-        width: 100%;
-        height: auto;
-        margin-top: 30px;
-
-        &__img {
-            display: block;
-            width: 100%;
-            height: auto;
-        }
-    }
+  }
 }
 
 //skills
 .skills {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 50px;
+  gap: 2.5rem;
+
+  &--carousel {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-top: 50px;
-    gap: 2.5rem;
+    width: 100%;
+    overflow-x: scroll;
 
-    &--carousel {
-        display: flex;
-        width: 100%;
-        overflow-x: scroll;
+    .carousel--wrapper {
+      max-width: 620px;
+      display: flex;
+      flex-direction: row;
+      gap: 20px;
 
-        .carousel--wrapper {
-            max-width: 620px;
-            display: flex;
-            flex-direction: row;
-            gap: 20px;
+      &__item {
+        width: 60px;
+        height: auto;
 
-            &__item {
-                width: 60px;
-                height: auto;
-
-                img {
-                    width: 100%;
-                    height: auto;
-                }
-            }
+        img {
+          width: 100%;
+          height: auto;
         }
-
-        &::-webkit-scrollbar {
-            display: none;
-        }
+      }
     }
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 }
 
 .skillPc {
-    display: none;
+  display: none;
 }
 
 .experiences {
-    .experience {
-        position: sticky;
-        top: 0vh;
-        padding-top: 36px;
-        padding-bottom: 64px;
-        border-radius: 10px;
-        background-color: white;
+  .experience {
+    position: sticky;
+    top: 0vh;
+    padding-top: 36px;
+    padding-bottom: 64px;
+    border-radius: 10px;
+    background-color: white;
 
-        &--media {
-            width: 100%;
-            height: auto;
-            display: flex;
-            justify-content: center;
-            align-items: center;
+    &--media {
+      width: 100%;
+      height: auto;
+      display: flex;
+      justify-content: center;
+      align-items: center;
 
-            &__img {
-                width: 100%;
-            }
-        }
-
-        &--txt {
-            display: flex;
-            flex-direction: column;
-
-            &__year {
-                font-size: 16px;
-                margin-bottom: 8px;
-            }
-
-            &__title {
-                margin-bottom: 16px;
-                font-size: 48px;
-            }
-
-            &__description {
-                font-size: 20px;
-            }
-        }
+      &__img {
+        width: 100%;
+      }
     }
+
+    &--txt {
+      display: flex;
+      flex-direction: column;
+
+      &__year {
+        font-size: 16px;
+        margin-bottom: 8px;
+      }
+
+      &__title {
+        margin-bottom: 16px;
+        font-size: 48px;
+      }
+
+      &__description {
+        font-size: 20px;
+      }
+    }
+  }
 }
 
 .contact {
-    text-align: center;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+
+  .contactContainer {
     display: flex;
     flex-direction: column;
-    gap: 30px;
+    gap: 2.5rem;
 
-    .contactContainer {
-        display: flex;
-        flex-direction: column;
-        gap: 2.5rem;
+    &--social {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      margin-top: 30px;
+      margin-left: auto;
+      margin-right: auto;
 
-        &--social {
-            display: flex;
-            flex-direction: column;
-            gap: 1.5rem;
-            margin-top: 30px;
-            margin-left: auto;
-            margin-right: auto;
+      &__item {
+        a {
+          display: flex;
+          justify-content: left;
+          align-items: center;
+          gap: 1.5rem;
+          font-size: 24px;
+          font-family: 'Tilt Neon', cursive;
+          color: black;
 
-            &__item {
+          .socialIcon {
+            width: 40px;
+            height: auto;
 
-                a {
-                    display: flex;
-                    justify-content: left;
-                    align-items: center;
-                    gap: 1.5rem;
-                    font-size: 24px;
-                    font-family: 'Tilt Neon', cursive;
-                    color: black;
-
-                    .socialIcon {
-                        width: 40px;
-                        height: auto;
-
-                        img {
-                            display: block;
-                            width: 100%;
-                            height: auto;
-                        }
-                    }
-                }
+            img {
+              display: block;
+              width: 100%;
+              height: auto;
             }
+          }
         }
-
-        .form-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: 5px;
-
-            .form {
-
-                &--field {
-                    position: relative;
-                    margin-bottom: 35px;
-                    width: 100%;
-                    max-width: 300px;
-
-                    textarea {
-                        display: block;
-                        margin-right: 0;
-                        height: 300px;
-                    }
-
-                    &__label {
-                        position: absolute;
-                        font-family: 'Tilt Neon', cursive;
-                        font-size: 20px;
-                        top: 10px;
-                        left: 16px;
-                        color: #8c9198;
-                        transition: 0.3s ease-in-out;
-                    }
-
-                    &__input {
-                        color: black;
-                        padding: 10px 15px;
-                        font-size: 20px;
-                        font-family: 'Tilt Neon', cursive;
-                        border-radius: 15px;
-                        transition: 0.3s ease-in-out;
-                        border: 1px solid #c6c6cd;
-                        transition: 0.001s ease-in-out;
-
-                        &:focus {
-                            outline: 0;
-                        }
-                    }
-
-                    .inputFocusEffect {
-                        font-size: 16px;
-                        top: -20px;
-                    }
-
-                    .textAreaEffect {
-                        border: #90EE90 1px solid;
-                    }
-
-                }
-
-                &--btn {
-                    all: unset;
-                    font-family: 'Tilt Neon', cursive;
-                    font-size: 20px;
-                    max-width: 200px;
-                    width: 60%;
-                    padding: 10px 15px;
-                    border-radius: 15px;
-                    border: 1px solid black;
-                    background-color: black;
-                    color: white;
-                    text-align: center;
-                    cursor: pointer;
-                    transition: 0.3s ease-in-out;
-                }
-            }
-
-            .formBtnEffect {
-                background-color: #90EE90;
-                border: #90EE90 1px solid;
-            }
-
-            .emailSentWRapper {
-                height: 0%;
-                box-shadow: none;
-                transition: 0.3s ease-in-out;
-            }
-
-        }
-
-        .formBlur {
-            position: relative;
-
-            .emailSentWRapper {
-                height: 100%;
-                position: absolute;
-                left: 0;
-                top: 0;
-                right: 0;
-                display: flex;
-                flex-wrap: wrap;
-                flex-direction: column;
-                justify-content: center;
-                align-content: center;
-                background-color: #ffffff29;
-                backdrop-filter: blur(5px);
-                color: #90EE90;
-                font-family: "Tilt Neon", cursive;
-
-                &--media {
-                    width: 100%;
-                    height: auto;
-                    margin-top: 15px;
-                    max-width: 100px;
-
-                    img {
-                        display: block;
-                        width: 100%;
-                    }
-                }
-            }
-        }
+      }
     }
-}
 
+    .form-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 5px;
+
+      .form {
+        &--field {
+          position: relative;
+          margin-bottom: 35px;
+          width: 100%;
+          max-width: 300px;
+
+          textarea {
+            display: block;
+            margin-right: 0;
+            height: 300px;
+          }
+
+          &__label {
+            position: absolute;
+            font-family: 'Tilt Neon', cursive;
+            font-size: 20px;
+            top: 10px;
+            left: 16px;
+            color: #8c9198;
+            transition: 0.3s ease-in-out;
+          }
+
+          &__input {
+            color: black;
+            padding: 10px 15px;
+            font-size: 20px;
+            font-family: 'Tilt Neon', cursive;
+            border-radius: 15px;
+            transition: 0.3s ease-in-out;
+            border: 1px solid #c6c6cd;
+            transition: 0.001s ease-in-out;
+
+            &:focus {
+              outline: 0;
+            }
+          }
+
+          .inputFocusEffect {
+            font-size: 16px;
+            top: -20px;
+          }
+
+          .textAreaEffect {
+            border: #90ee90 1px solid;
+          }
+        }
+
+        &--btn {
+          all: unset;
+          font-family: 'Tilt Neon', cursive;
+          font-size: 20px;
+          max-width: 200px;
+          width: 60%;
+          padding: 10px 15px;
+          border-radius: 15px;
+          border: 1px solid black;
+          background-color: black;
+          color: white;
+          text-align: center;
+          cursor: pointer;
+          transition: 0.3s ease-in-out;
+        }
+      }
+
+      .formBtnEffect {
+        background-color: #90ee90;
+        border: #90ee90 1px solid;
+      }
+
+      .emailSentWRapper {
+        height: 0%;
+        box-shadow: none;
+        transition: 0.3s ease-in-out;
+      }
+    }
+
+    .formBlur {
+      position: relative;
+
+      .emailSentWRapper {
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        display: flex;
+        flex-wrap: wrap;
+        flex-direction: column;
+        justify-content: center;
+        align-content: center;
+        background-color: #ffffff29;
+        backdrop-filter: blur(5px);
+        color: #90ee90;
+        font-family: 'Tilt Neon', cursive;
+
+        &--media {
+          width: 100%;
+          height: auto;
+          margin-top: 15px;
+          max-width: 100px;
+
+          img {
+            display: block;
+            width: 100%;
+          }
+        }
+      }
+    }
+  }
+}
 
 //tablet
 @media screen and (min-width: 768px) {
-    h1 {
-        font-size: 60px;
+  h1 {
+    font-size: 60px;
+  }
+
+  h2 {
+    font-size: 45px;
+  }
+
+  p {
+    font-size: 22px;
+  }
+
+  * {
+    scroll-behavior: smooth;
+  }
+
+  .wrapper {
+    padding-top: 130px;
+  }
+
+  .navbar {
+    padding: 30px 6%;
+
+    &--logo {
+      width: 45px;
+      height: 45px;
     }
 
-    h2 {
-        font-size: 45px;
-    }
+    &--menu {
+      width: auto;
+      height: auto;
 
-    p {
-        font-size: 22px;
-    }
-
-    * {
-        scroll-behavior: smooth;
-    }
-
-    .wrapper {
-        padding-top: 130px;
-    }
-
-    .navbar {
-        padding: 30px 6%;
-
-        &--logo {
-            width: 45px;
-            height: 45px;
-        }
-
-        &--menu {
-            width: auto;
-            height: auto;
-
-            &__hamburger {
-                display: none;
-            }
-
-            &__list {
-                all: unset;
-                position: static;
-                background-color: rgba(255, 255, 255, 0);
-                color: black;
-                display: flex;
-                gap: 40px;
-
-                li {
-                    padding: 5px 10px;
-
-                    a {
-                        font-size: 20px;
-                        font-family: 'Courier New', Courier, monospace;
-                        font-weight: bold;
-                        color: black;
-                    }
-
-                    &::after {
-                        display: block;
-                        content: "";
-                        width: 0%;
-                        height: 2px;
-                        background-color: black;
-                        transition: 0.3s ease-in-out;
-                    }
-
-                    &:hover {
-                        &::after {
-                            width: 100%;
-                        }
-                    }
-                }
-
-                .liClickEffect {
-                    position: static;
-                    transform: translateY(0);
-                    opacity: 1;
-                }
-            }
-
-            .menuClickEffect {
-                transform: translateY(0);
-            }
-        }
-    }
-
-    .main {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-evenly;
-        align-items: center;
-
-        &--text {
-            order: 1;
-        }
-    }
-
-    .about {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 20px;
-        justify-content: center;
-        align-items: center;
-
-        &--text {
-            justify-content: center;
-        }
-
-        &--media {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-    }
-
-    .skills {
+      &__hamburger {
         display: none;
+      }
+
+      &__list {
+        all: unset;
+        position: static;
+        background-color: rgba(255, 255, 255, 0);
+        color: black;
+        display: flex;
+        gap: 40px;
+
+        li {
+          padding: 5px 10px;
+
+          a {
+            font-size: 20px;
+            font-family: 'Courier New', Courier, monospace;
+            font-weight: bold;
+            color: black;
+          }
+
+          &::after {
+            display: block;
+            content: '';
+            width: 0%;
+            height: 2px;
+            background-color: black;
+            transition: 0.3s ease-in-out;
+          }
+
+          &:hover {
+            &::after {
+              width: 100%;
+            }
+          }
+        }
+
+        .liClickEffect {
+          position: static;
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+
+      .menuClickEffect {
+        transform: translateY(0);
+      }
+    }
+  }
+
+  .main {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
+
+    &--text {
+      order: 1;
+    }
+  }
+
+  .about {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    justify-content: center;
+    align-items: center;
+
+    &--text {
+      justify-content: center;
     }
 
-    .skillPc {
+    &--media {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+
+  .skills {
+    display: none;
+  }
+
+  .skillPc {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: auto;
+    justify-content: space-between;
+    position: relative;
+
+    &--title {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      h1 {
+        padding: 15px 20px;
+        font-size: 42px;
+        border-radius: 20px;
+        box-shadow:
+          rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+          rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+          rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+      }
+    }
+
+    .skillWrapper {
+      height: auto;
+      max-width: 500px;
+      padding: 30px;
+      margin-left: auto;
+      margin-right: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 25px;
+      border-radius: 20px;
+      transition: 0.3s ease-in-out;
+      cursor: pointer;
+
+      &--text {
+        &__title {
+          font-size: 32px;
+        }
+      }
+
+      .skillsPc {
+        height: auto;
         display: grid;
         grid-template-columns: repeat(3, 1fr);
-        grid-template-rows: auto;
-        justify-content: space-between;
-        position: relative;
+        grid-column-gap: 20%;
 
-        &--title {
-            display: flex;
-            justify-content: center;
-            align-items: center;
+        &--container {
+          max-width: 80px;
+          margin-bottom: 25px;
 
-            h1 {
-                padding: 15px 20px;
-                font-size: 42px;
-                border-radius: 20px;
-                box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
-            }
+          &__item {
+            width: 100%;
+            display: block;
+          }
         }
+      }
 
-        .skillWrapper {
-            height: auto;
-            max-width: 500px;
-            padding: 30px;
-            margin-left: auto;
-            margin-right: auto;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 25px;
-            border-radius: 20px;
-            transition: 0.3s ease-in-out;
-            cursor: pointer;
+      &:hover {
+        box-shadow:
+          rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+          rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+          rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+        transform: translateY(-20px);
+      }
+    }
+  }
 
-            &--text {
-                &__title {
-                    font-size: 32px;
-                }
-            }
-
-            .skillsPc {
-                height: auto;
-                display: grid;
-                grid-template-columns: repeat(3, 1fr);
-                grid-column-gap: 20%;
-
-
-                &--container {
-                    max-width: 80px;
-                    margin-bottom: 25px;
-
-                    &__item {
-                        width: 100%;
-                        display: block;
-                    }
-                }
-
-            }
-
-            &:hover {
-                box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
-                transform: translateY(-20px);
-            }
-        }
+  .experiences {
+    &--title {
+      text-align: center;
+      margin-bottom: 30px;
     }
 
-    .experiences {
-        &--title {
-            text-align: center;
-            margin-bottom: 30px;
-        }
+    .experience {
+      margin-bottom: 20px;
+      box-shadow:
+        rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
+        rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
+        rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
+      padding: 48px;
 
-        .experience {
-            margin-bottom: 20px;
-            box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
-            padding: 48px;
+      &--content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+      }
 
-            &--content {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-            }
-
-            &--txt {
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-            }
-        }
+      &--txt {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
     }
+  }
 
-    .contact {
-        gap: 60px;
+  .contact {
+    gap: 60px;
 
-        .contactContainer {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-        }
+    .contactContainer {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
     }
+  }
 }
 
 //pc
 @media screen and (min-width: 992px) {
-    h1 {
-        font-size: 65px;
+  h1 {
+    font-size: 65px;
+  }
+
+  h2 {
+    font-size: 56px;
+  }
+
+  p {
+    font-size: 24px;
+  }
+
+  .wrapper {
+    padding-top: 60px;
+    padding-bottom: 80px;
+  }
+
+  .experiences {
+    &--title {
+      margin-bottom: 76px;
     }
 
-    h2 {
-        font-size: 56px;
+    .experience {
+      &--content {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 2.5rem;
+      }
+
+      &--txt {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
     }
+  }
 
-    p {
-        font-size: 24px;
-    }
+  .contact {
+    margin-top: 120px;
+    gap: 60px;
 
-    .wrapper {
-        padding-top: 60px;
-        padding-bottom: 80px;
-    }
+    .contactContainer {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      align-items: center;
 
-    .experiences {
+      .form-wrapper {
+        position: relative;
 
-        &--title {
-            margin-bottom: 76px;
+        .form {
+          width: 100%;
+          display: flex;
+          flex-direction: row;
+          gap: 40px;
         }
 
-        .experience {
-
-            &--content {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 2.5rem;
-            }
-
-            &--txt {
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-            }
+        .form--btn {
+          position: absolute;
+          bottom: 55px;
+          left: 6px;
+          width: 215px;
+          transition: 0.3s ease-in-out;
         }
+      }
     }
-
-    .contact {
-        margin-top: 120px;
-        gap: 60px;
-
-        .contactContainer {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            align-items: center;
-
-            .form-wrapper {
-                position: relative;
-
-                .form {
-                    width: 100%;
-                    display: flex;
-                    flex-direction: row;
-                    gap: 40px;
-                }
-
-                .form--btn {
-                    position: absolute;
-                    bottom: 55px;
-                    left: 6px;
-                    width: 215px;
-                    transition: 0.3s ease-in-out;
-                }
-            }
-        }
-    }
+  }
 }


### PR DESCRIPTION
## Summary
- Introduce value-focused hero headline with project/CV CTAs
- Add dynamic Projects section and reorganize Skills into Core, Used and Learning categories
- Enrich experience entries with responsibilities and outcomes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint docs` *(fails: config uses unsupported "extends" key)*

------
https://chatgpt.com/codex/tasks/task_e_689b0adf8028832da72d1dcee495a0a1