### PR TITLE
Add SEO metadata and sitemap

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Not Found</title>
+  </head>
+  <body>
+    <main>
+      <h1>404 - Page Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
+      <a href="/">Back to home</a>
+    </main>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,25 +4,41 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Janmanpreet</title>
+    <title>Janmanpreet Singh</title>
+    <meta
+      name="description"
+      content="Personal portfolio of Janmanpreet Singh, software engineer specializing in Go, Fiber, and Postgres, showcasing projects, skills, experience, and contact info."
+    />
+    <link rel="canonical" href="https://www.janmanpreet.com/" />
+    <meta name="robots" content="index, follow" />
     <link
       rel="icon"
       href="https://placehold.co/256x256/png"
       type="image/png"
     />
     <!-- meta tags -->
-    <meta charset="utf-8" />
-    <title>Janmanpreet Singh</title>
     <!-- Search Engine -->
     <meta name="image" content="https://placehold.co/256x256/png" />
     <!-- Schema.org for Google -->
     <meta itemprop="name" content="Janmanpreet Singh" />
     <meta itemprop="image" content="https://placehold.co/256x256/png" />
-    <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-    <meta name="og:title" content="Janmanpreet Singh" />
-    <meta name="og:url" content="https://www.janmanpreet.com/" />
-    <meta name="og:site_name" content="Janmanpreet" />
-    <meta name="og:type" content="website" />
+    <!-- Open Graph / Twitter -->
+    <meta property="og:title" content="Janmanpreet Singh" />
+    <meta
+      property="og:description"
+      content="Personal portfolio of Janmanpreet Singh, software engineer specializing in Go, Fiber, and Postgres, showcasing projects, skills, experience, and contact info."
+    />
+    <meta property="og:image" content="https://placehold.co/1200x630.webp" />
+    <meta property="og:url" content="https://www.janmanpreet.com/" />
+    <meta property="og:site_name" content="Janmanpreet" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Janmanpreet Singh" />
+    <meta
+      name="twitter:description"
+      content="Personal portfolio of Janmanpreet Singh, software engineer specializing in Go, Fiber, and Postgres, showcasing projects, skills, experience, and contact info."
+    />
+    <meta name="twitter:image" content="https://placehold.co/1200x630.webp" />
     <!-- fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -30,6 +46,24 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Space+Grotesk:wght@700&display=swap"
       rel="stylesheet"
     />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Janmanpreet Singh",
+        "jobTitle": "Software Engineer",
+        "url": "https://www.janmanpreet.com/",
+        "sameAs": [
+          "https://github.com/Erodot0",
+          "https://www.linkedin.com/in/janmanpreet/"
+        ],
+        "knowsAbout": ["Go", "Fiber", "Postgres"],
+        "worksFor": {
+          "@type": "Organization",
+          "name": "Self-employed"
+        }
+      }
+    </script>
     <style>
       :root {
         --font-sans: 'Inter', sans-serif;

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.janmanpreet.com/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.janmanpreet.com/</loc>
+    <lastmod>2025-08-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- clean up head and add SEO meta tags
- include structured data for person and social sharing tags
- provide sitemap, robots rules, and 404 page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_689b225efe18832d978144ffcaa6c981